### PR TITLE
feat: use slurm snap for slurmrestd operations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,12 +65,16 @@ jobs:
 
   integration-test:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        bases:          
+        bases:
           - ubuntu@22.04
-    name: Integration tests (LXD) | ${{ matrix.bases }}
+        local: [true, false]
+    name: Integration tests (LXD) ${{ matrix.local && '|' || '| Charmhub (edge) |'}} ${{ matrix.bases }}
     runs-on: ubuntu-latest
+    # Testing against Charmhub will probably yield errors when doing breaking changes, so don't
+    # block CI on that.
+    continue-on-error: ${{ !matrix.local }}
     needs:
       - inclusive-naming-check
       - lint
@@ -79,10 +83,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: main
+      - name: Fetch slurmctld
+        uses: actions/checkout@v4
+        if: ${{ matrix.local }}
+        with:
+          repository: charmed-hpc/slurmctld-operator
+          path: slurmctld-operator
+      - name: Fetch slurmdbd
+        uses: actions/checkout@v4
+        if: ${{ matrix.local }}
+        with:
+          repository: charmed-hpc/slurmdbd-operator
+          path: slurmdbd-operator
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          juju-channel: 3.1/stable
+          juju-channel: 3.4/stable
       - name: Run tests
-        run: tox run -e integration -- --charm-base=${{ matrix.bases }}
+        run: |
+          cd main && tox run -e integration -- \
+             --charm-base=${{ matrix.bases }} \
+             ${{ matrix.local && '--use-local' || '' }}

--- a/.github/workflows/experimental.yaml
+++ b/.github/workflows/experimental.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: slurmrestd charm tests
+name: slurmdbd charm tests (experimental)
 on:
-  workflow_call:
   pull_request:
     branches:
-      - main
+      - experimental
 
 jobs:
   inclusive-naming-check:
@@ -26,15 +25,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: woke
+      - name: Run tests
         uses: get-woke/woke-action@v0
         with:
-          # Cause the check to fail on any broke rules
           fail-on-error: true
 
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,17 +40,6 @@ jobs:
         run: python3 -m pip install tox
       - name: Run linters
         run: tox -e lint
-
-  type:
-    name: Type checking
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run tests
-        run: tox -e type
 
   unit-test:
     name: Unit tests
@@ -65,18 +52,25 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
+  type:
+    name: Type checking
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run tests
+        run: tox -e type
+
   integration-test:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         bases:
           - ubuntu@22.04
-        local: [true, false]
-    name: Integration tests (LXD) ${{ matrix.local && '|' || '| Charmhub (edge) |'}} ${{ matrix.bases }}
+    name: Integration tests (LXD) | ${{ matrix.bases }}
     runs-on: ubuntu-latest
-    # Testing against Charmhub will probably yield errors when doing breaking changes, so don't
-    # block CI on that.
-    continue-on-error: ${{ !matrix.local }}
     needs:
       - inclusive-naming-check
       - lint
@@ -89,16 +83,16 @@ jobs:
           path: main
       - name: Fetch slurmctld
         uses: actions/checkout@v4
-        if: ${{ matrix.local }}
         with:
           repository: charmed-hpc/slurmctld-operator
           path: slurmctld-operator
+          ref: experimental
       - name: Fetch slurmdbd
         uses: actions/checkout@v4
-        if: ${{ matrix.local }}
         with:
           repository: charmed-hpc/slurmdbd-operator
           path: slurmdbd-operator
+          ref: experimental
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -108,4 +102,4 @@ jobs:
         run: |
           cd main && tox run -e integration -- \
              --charm-base=${{ matrix.bases }} \
-             ${{ matrix.local && '--use-local' || '' }}
+             --use-local

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,10 +32,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.2.0
+        uses: canonical/charming-actions/channel@2.5.0-rc
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.0
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -1,0 +1,308 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Abstractions for managing Slurm operations via snap.
+
+This library contains the `SlurmManagerBase` and `ServiceType` class
+which provide high-level interfaces for managing Slurm within charmed operators.
+
+### Example Usage
+
+#### Managing a Slurm service
+
+The `SlurmManagerBase` constructor receives a `ServiceType` enum. The enum instructs
+the inheriting Slurm service manager how to manage its corresponding Slurm service on the host.
+
+```python3
+import charms.hpc_libs.v0.slurm_ops as slurm
+from charms.hpc_libs.v0.slurm_ops import SlurmManagerBase, ServiceType
+
+class SlurmctldManager(SlurmManagerBase):
+    # Manage `slurmctld` service on host.
+
+    def __init__(self) -> None:
+        super().__init__(ServiceType.SLURMCTLD)
+
+
+class ApplicationCharm(CharmBase):
+    # Application charm that needs to use the Slurm snap.
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self._slurm_manager = SlurmctldManager()
+        self.framework.observe(
+            self.on.install,
+            self._on_install,
+        )
+
+    def _on_install(self, _) -> None:
+        slurm.install()
+        self.unit.set_workload_version(slurm.version())
+        self._slurm_manager.config.set({"cluster-name": "cluster"})
+```
+"""
+
+__all__ = [
+    "format_key",
+    "install",
+    "version",
+    "ConfigurationManager",
+    "ServiceType",
+    "SlurmManagerBase",
+    "SlurmOpsError",
+]
+
+import json
+import logging
+import re
+import socket
+import subprocess
+from collections.abc import Mapping
+from enum import Enum
+from typing import Any, Optional
+
+import yaml
+
+# The unique Charmhub library identifier, never change it
+LIBID = "541fd767f90b40539cf7cd6e7db8fabf"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 5
+
+# Charm library dependencies to fetch during `charmcraft pack`.
+PYDEPS = ["pyyaml>=6.0.1"]
+
+_logger = logging.getLogger(__name__)
+_acronym = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])")
+_kebabize = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+
+class SlurmOpsError(Exception):
+    """Exception raised when a slurm operation failed."""
+
+    @property
+    def message(self) -> str:
+        """Return message passed as argument to exception."""
+        return self.args[0]
+
+
+def format_key(key: str) -> str:
+    """Format Slurm configuration keys from SlurmCASe into kebab case.
+
+    Args:
+        key: Slurm configuration key to convert to kebab case.
+
+    Notes:
+       Slurm configuration syntax does not follow proper PascalCasing
+       format, so we cannot put keys directly through a kebab case converter
+       to get the desired format. Some additional processing is needed for
+       certain keys before the key can properly kebabized.
+
+       For example, without additional preprocessing, the key `CPUs` will
+       become `cp-us` if put through a kebabizer with being preformatted to `Cpus`.
+    """
+    if "CPUs" in key:
+        key = key.replace("CPUs", "Cpus")
+    key = _acronym.sub(r"-", key)
+    return _kebabize.sub(r"-", key).lower()
+
+
+def install() -> None:
+    """Install Slurm."""
+    # FIXME: Pin slurm to the stable channel
+    _snap("install", "slurm", "--channel", "latest/candidate", "--classic")
+
+
+def version() -> str:
+    """Get the current version of Slurm installed on the system."""
+    info = yaml.safe_load(_snap("info", "slurm"))
+    if (ver := info.get("installed")) is None:
+        raise SlurmOpsError("unable to retrive snap info. Ensure slurm is correctly installed")
+    return ver.split(maxsplit=1)[0]
+
+
+def _call(cmd: str, *args: str, stdin: Optional[str] = None) -> str:
+    """Call a command with logging.
+
+    Raises:
+        SlurmOpsError: Raised if the command fails.
+    """
+    cmd = [cmd, *args]
+    _logger.debug(f"Executing command {cmd}")
+    try:
+        return subprocess.check_output(cmd, input=stdin, stderr=subprocess.PIPE, text=True).strip()
+    except subprocess.CalledProcessError as e:
+        _logger.error(f"`{' '.join(cmd)}` failed")
+        _logger.error(f"stderr: {e.stderr.decode()}")
+        raise SlurmOpsError(f"command {cmd[0]} failed. Reason:\n{e.stderr.decode()}")
+
+
+def _snap(*args) -> str:
+    """Control snap by via executed `snap ...` commands.
+
+    Raises:
+        subprocess.CalledProcessError: Raised if snap command fails.
+    """
+    return _call("snap", *args)
+
+
+def _mungectl(*args: str, stdin: Optional[str] = None) -> str:
+    """Control munge via `slurm.mungectl ...`.
+
+    Args:
+        *args: Arguments to pass to `mungectl`.
+        stdin: Input to pass to `mungectl` via stdin.
+
+    Raises:
+        subprocess.CalledProcessError: Raised if `mungectl` command fails.
+    """
+    return _call("slurm.mungectl", *args, stdin=stdin)
+
+
+class ServiceType(Enum):
+    """Type of Slurm service to manage."""
+
+    MUNGED = "munged"
+    PROMETHEUS_EXPORTER = "slurm-prometheus-exporter"
+    SLURMD = "slurmd"
+    SLURMCTLD = "slurmctld"
+    SLURMDBD = "slurmdbd"
+    SLURMRESTD = "slurmrestd"
+
+    @property
+    def config_name(self) -> str:
+        """Configuration name on the slurm snap for this service type."""
+        if self is ServiceType.SLURMCTLD:
+            return "slurm"
+        if self is ServiceType.MUNGED:
+            return "munge"
+
+        return self.value
+
+
+class ServiceManager:
+    """Control a Slurm service."""
+
+    def enable(self) -> None:
+        """Enable service."""
+        _snap("start", "--enable", f"slurm.{self._service.value}")
+
+    def disable(self) -> None:
+        """Disable service."""
+        _snap("stop", "--disable", f"slurm.{self._service.value}")
+
+    def restart(self) -> None:
+        """Restart service."""
+        _snap("restart", f"slurm.{self._service.value}")
+
+    def active(self) -> bool:
+        """Return True if the service is active."""
+        info = yaml.safe_load(_snap("info", "slurm"))
+        if (services := info.get("services")) is None:
+            raise SlurmOpsError("unable to retrive snap info. Ensure slurm is correctly installed")
+
+        # Assume `services` contains the service, since `ServiceManager` is not exposed as a
+        # public interface for now.
+        # We don't do `"active" in state` because the word "active" is also part of "inactive" :)
+        return "inactive" not in services[f"slurm.{self._service.value}"]
+
+
+class ConfigurationManager:
+    """Control configuration of a Slurm component."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def get_options(self, *keys: str) -> Mapping[str, Any]:
+        """Get given configurations values for Slurm component."""
+        configs = {}
+        for key in keys:
+            config = self.get(key)
+            target = key.rsplit(".", maxsplit=1)[-1]
+            configs[target] = config
+
+        return configs
+
+    def get(self, key: Optional[str] = None) -> Any:
+        """Get specific configuration value for Slurm component."""
+        key = f"{self._name}.{key}" if key else self._name
+        config = json.loads(_snap("get", "-d", "slurm", key))
+        return config[key]
+
+    def set(self, config: Mapping[str, Any]) -> None:
+        """Set configuration for Slurm component."""
+        args = [f"{self._name}.{k}={json.dumps(v)}" for k, v in config.items()]
+        _snap("set", "slurm", *args)
+
+    def unset(self, *keys: str) -> None:
+        """Unset configuration for Slurm component."""
+        args = [f"{self._name}.{k}" for k in keys] if len(keys) > 0 else [self._name]
+        _snap("unset", "slurm", *args)
+
+
+class MungeManager(ServiceManager):
+    """Manage `munged` service operations."""
+
+    def __init__(self) -> None:
+        service = ServiceType.MUNGED
+        self._service = service
+        self.config = ConfigurationManager(service.config_name)
+
+    def get_key(self) -> str:
+        """Get the current munge key.
+
+        Returns:
+            The current munge key as a base64-encoded string.
+        """
+        return _mungectl("key", "get")
+
+    def set_key(self, key: str) -> None:
+        """Set a new munge key.
+
+        Args:
+            key: A new, base64-encoded munge key.
+        """
+        _mungectl("key", "set", stdin=key)
+
+    def generate_key(self) -> None:
+        """Generate a new, cryptographically secure munge key."""
+        _mungectl("key", "generate")
+
+
+class PrometheusExporterManager(ServiceManager):
+    """Manage `slurm-prometheus-exporter` service operations."""
+
+    def __init__(self) -> None:
+        self._service = ServiceType.PROMETHEUS_EXPORTER
+
+
+class SlurmManagerBase(ServiceManager):
+    """Base manager for Slurm services."""
+
+    def __init__(self, service: ServiceType) -> None:
+        self._service = service
+        self.config = ConfigurationManager(service.config_name)
+        self.munge = MungeManager()
+        self.exporter = PrometheusExporterManager()
+
+    @property
+    def hostname(self) -> str:
+        """The hostname where this manager is running."""
+        return socket.gethostname().split(".")[0]

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,67 +3,9 @@
 """constants for slurmrestd-operator."""
 from pathlib import Path
 
-SLURMRESTD_GROUP_GID = 64031
-SLURMRESTD_USER_UID = 64031
-SLURMRESTD_USER_NAME = "slurmrestd"
-SLURMRESTD_GROUP_NAME = "slurmrestd"
+SNAP_COMMON = Path("/var/snap/slurm/common")
 
-MUNGE_KEY_PATH = Path("/etc/munge/munge.key")
+SLURMRESTD_GROUP_GID = 584788  # snap_daemon
+SLURMRESTD_USER_UID = 584788  # snap_daemon
 
-SLURMRESTD_SERVICE = """
-[Unit]
-Description=Slurm REST daemon
-After=network.target munge.service slurmctld.service
-ConditionPathExists=/etc/slurm/slurm.conf
-Documentation=man:slurmrestd(8)
-
-[Service]
-Type=simple
-EnvironmentFile=-/etc/default/slurmrestd
-Environment="SLURM_JWT=daemon"
-ExecStart=/usr/sbin/slurmrestd $SLURMRESTD_OPTIONS -vv 0.0.0.0:6820
-ExecReload=/bin/kill -HUP $MAINPID
-User=slurmrestd
-Group=slurmrestd
-
-# Restart service if failed
-Restart=on-failure
-RestartSec=30s
-
-[Install]
-WantedBy=multi-user.target
-"""
-
-
-UBUNTU_HPC_PPA_KEY = """
------BEGIN PGP PUBLIC KEY BLOCK-----
-Comment: Hostname:
-Version: Hockeypuck 2.1.1-10-gec3b0e7
-
-xsFNBGTuZb8BEACtJ1CnZe6/hv84DceHv+a54y3Pqq0gqED0xhTKnbj/E2ByJpmT
-NlDNkpeITwPAAN1e3824Me76Qn31RkogTMoPJ2o2XfG253RXd67MPxYhfKTJcnM3
-CEkmeI4u2Lynh3O6RQ08nAFS2AGTeFVFH2GPNWrfOsGZW03Jas85TZ0k7LXVHiBs
-W6qonbsFJhshvwC3SryG4XYT+z/+35x5fus4rPtMrrEOD65hij7EtQNaE8owuAju
-Kcd0m2b+crMXNcllWFWmYMV0VjksQvYD7jwGrWeKs+EeHgU8ZuqaIP4pYHvoQjag
-umqnH9Qsaq5NAXiuAIAGDIIV4RdAfQIR4opGaVgIFJdvoSwYe3oh2JlrLPBlyxyY
-dayDifd3X8jxq6/oAuyH1h5K/QLs46jLSR8fUbG98SCHlRmvozTuWGk+e07ALtGe
-sGv78ToHKwoM2buXaTTHMwYwu7Rx8LZ4bZPHdersN1VW/m9yn1n5hMzwbFKy2s6/
-D4Q2ZBsqlN+5aW2q0IUmO+m0GhcdaDv8U7RVto1cWWPr50HhiCi7Yvei1qZiD9jq
-57oYZVqTUNCTPxi6NeTOdEc+YqNynWNArx4PHh38LT0bqKtlZCGHNfoAJLPVYhbB
-b2AHj9edYtHU9AAFSIy+HstET6P0UDxy02IeyE2yxoUBqdlXyv6FL44E+wARAQAB
-zRxMYXVuY2hwYWQgUFBBIGZvciBVYnVudHUgSFBDwsGOBBMBCgA4FiEErocSHcPk
-oLD4H/Aj9tDF1ca+s3sFAmTuZb8CGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AA
-CgkQ9tDF1ca+s3sz3w//RNawsgydrutcbKf0yphDhzWS53wgfrs2KF1KgB0u/H+u
-6Kn2C6jrVM0vuY4NKpbEPCduOj21pTCepL6PoCLv++tICOLVok5wY7Zn3WQFq0js
-Iy1wO5t3kA1cTD/05v/qQVBGZ2j4DsJo33iMcQS5AjHvSr0nu7XSvDDEE3cQE55D
-87vL7lgGjuTOikPh5FpCoS1gpemBfwm2Lbm4P8vGOA4/witRjGgfC1fv1idUnZLM
-TbGrDlhVie8pX2kgB6yTYbJ3P3kpC1ZPpXSRWO/cQ8xoYpLBTXOOtqwZZUnxyzHh
-gM+hv42vPTOnCo+apD97/VArsp59pDqEVoAtMTk72fdBqR+BB77g2hBkKESgQIEq
-EiE1/TOISioMkE0AuUdaJ2ebyQXugSHHuBaqbEC47v8t5DVN5Qr9OriuzCuSDNFn
-6SBHpahN9ZNi9w0A/Yh1+lFfpkVw2t04Q2LNuupqOpW+h3/62AeUqjUIAIrmfeML
-IDRE2VdquYdIXKuhNvfpJYGdyvx/wAbiAeBWg0uPSepwTfTG59VPQmj0FtalkMnN
-ya2212K5q68O5eXOfCnGeMvqIXxqzpdukxSZnLkgk40uFJnJVESd/CxHquqHPUDE
-fy6i2AnB3kUI27D4HY2YSlXLSRbjiSxTfVwNCzDsIh7Czefsm6ITK2+cVWs0hNQ=
-=cs1s
------END PGP PUBLIC KEY BLOCK-----
-"""
+SLURM_CONF_PATH = SNAP_COMMON / "etc/slurm/slurm.conf"

--- a/src/slurmrestd_ops.py
+++ b/src/slurmrestd_ops.py
@@ -5,23 +5,32 @@
 import logging
 import os
 import subprocess
-from base64 import b64decode
-from pathlib import Path
 
-import charms.operator_libs_linux.v0.apt as apt
+import charms.hpc_libs.v0.slurm_ops as slurm
 import charms.operator_libs_linux.v1.systemd as systemd
-import distro
+from charms.hpc_libs.v0.slurm_ops import ServiceType, SlurmManagerBase
 from constants import (
-    MUNGE_KEY_PATH,
+    SLURM_CONF_PATH,
     SLURMRESTD_GROUP_GID,
-    SLURMRESTD_GROUP_NAME,
-    SLURMRESTD_SERVICE,
-    SLURMRESTD_USER_NAME,
     SLURMRESTD_USER_UID,
-    UBUNTU_HPC_PPA_KEY,
 )
 
 logger = logging.getLogger()
+
+
+class SlurmrestdManager(SlurmManagerBase):
+    """Manage slurmrestd service operations."""
+
+    def __init__(self) -> None:
+        super().__init__(service=ServiceType.SLURMRESTD)
+
+    def install(self) -> None:
+        """Install slurmrestd and munge to the system."""
+        logger.debug("## Installing and configuring slurm.")
+
+        slurm.install()
+
+        os.chown(f"{SLURM_CONF_PATH.parent}", SLURMRESTD_USER_UID, SLURMRESTD_GROUP_GID)
 
 
 class SlurmrestdManagerError(BaseException):
@@ -32,136 +41,20 @@ class SlurmrestdManagerError(BaseException):
         self.message = message
 
 
-class CharmedHPCPackageLifecycleManager:
-    """Facilitate ubuntu-hpc slurm component package lifecycles."""
-
-    def __init__(self, package_name: str):
-        self._package_name = package_name
-        self._keyring_path = Path(f"/usr/share/keyrings/ubuntu-hpc-{self._package_name}.asc")
-
-    def _repo(self) -> apt.DebianRepository:
-        """Return the ubuntu-hpc repo."""
-        ppa_url: str = "https://ppa.launchpadcontent.net/ubuntu-hpc/slurm-wlm-23.02/ubuntu"
-        sources_list: str = (
-            f"deb [signed-by={self._keyring_path}] {ppa_url} {distro.codename()} main"
-        )
-        return apt.DebianRepository.from_repo_line(sources_list)
-
-    def install(self) -> bool:
-        """Install package using lib apt."""
-        package_installed = False
-
-        if self._keyring_path.exists():
-            self._keyring_path.unlink()
-        self._keyring_path.write_text(UBUNTU_HPC_PPA_KEY)
-
-        repositories = apt.RepositoryMapping()
-        repositories.add(self._repo())
-
-        try:
-            apt.update()
-            apt.add_package([self._package_name])
-            package_installed = True
-        except apt.PackageNotFoundError:
-            logger.error(f"'{self._package_name}' not found in package cache or on system.")
-        except apt.PackageError as e:
-            logger.error(f"Could not install '{self._package_name}'. Reason: {e.message}")
-
-        return package_installed
-
-    def uninstall(self) -> None:
-        """Uninstall the package using libapt."""
-        if apt.remove_package(self._package_name):
-            logger.info(f"'{self._package_name}' removed from system.")
-        else:
-            logger.error(f"'{self._package_name}' not found on system.")
-
-        repositories = apt.RepositoryMapping()
-        repositories.disable(self._repo())
-
-        if self._keyring_path.exists():
-            self._keyring_path.unlink()
-
-    def upgrade_to_latest(self) -> None:
-        """Upgrade package to latest."""
-        try:
-            slurm_package = apt.DebianPackage.from_system(self._package_name)
-            slurm_package.ensure(apt.PackageState.Latest)
-            logger.info(f"Updated '{self._package_name}' to: {slurm_package.version.number}.")
-        except apt.PackageNotFoundError:
-            logger.error(f"'{self._package_name}' not found in package cache or on system.")
-        except apt.PackageError as e:
-            logger.error(f"Could not install '{self._package_name}'. Reason: {e.message}")
-
-    def version(self) -> str:
-        """Return the package version."""
-        slurm_package_vers = ""
-        try:
-            slurm_package_vers = apt.DebianPackage.from_installed_package(
-                self._package_name
-            ).version.number
-        except apt.PackageNotFoundError:
-            logger.error(f"'{self._package_name}' not found on system.")
-        return slurm_package_vers
-
-
-class SlurmrestdManager:
-    """SlurmrestdManager."""
-
-    def __init__(self):
-        self._munge_package = CharmedHPCPackageLifecycleManager("munge")
-        self._slurmrestd_package = CharmedHPCPackageLifecycleManager("slurmrestd")
-        self._slurm_plugins_package = CharmedHPCPackageLifecycleManager("slurm-wlm-basic-plugins")
-
-    def install(self) -> bool:
-        """Install slurmrestd and munge to the system."""
-        logger.debug("Installing and configuring slurmrestd and munge packages.")
-
-        if self._slurmrestd_package.install() is not True:
-            return False
-        systemd.service_stop("slurmrestd")
-
-        if self._munge_package.install() is not True:
-            return False
-        systemd.service_stop("munge")
-
-        if self._slurm_plugins_package.install() is not True:
-            return False
-
-        self._create_slurmrestd_user_group()
-
-        slurm_conf_dir = Path("/etc/slurm")
-        slurm_conf_dir.mkdir(exist_ok=True)
-
-        os.chown(f"{slurm_conf_dir}", SLURMRESTD_USER_UID, SLURMRESTD_GROUP_GID)
-
-        logger.debug("Replacing slurmrestd.service")
-        target = Path("/usr/lib/systemd/system/slurmrestd.service")
-        target.write_text(SLURMRESTD_SERVICE)
-        systemd.daemon_reload()
-
-        return True
-
-    def version(self) -> str:
-        """Return slurm version."""
-        return self._slurmrestd_package.version()
+class LegacySlurmrestdManager:
+    """Legacy slurmrestd ops manager."""
 
     def write_slurm_conf(self, slurm_conf: str) -> None:
         """Render /etc/slurm/slurm.conf."""
-        target = Path("/etc/slurm/slurm.conf")
-        logger.debug(f"Writing slurm.conf: {target}")
+        logger.debug(f"Writing slurm.conf: {SLURM_CONF_PATH}")
 
-        target.write_text(slurm_conf)
+        SLURM_CONF_PATH.write_text(slurm_conf)
 
-        os.chown(f"{target}", SLURMRESTD_USER_UID, SLURMRESTD_GROUP_GID)
-
-    def write_munge_key(self, munge_key: str) -> None:
-        """Base64 decode and write the munge key."""
-        MUNGE_KEY_PATH.write_bytes(b64decode(munge_key.encode()))
+        os.chown(f"{SLURM_CONF_PATH}", SLURMRESTD_USER_UID, SLURMRESTD_GROUP_GID)
 
     def check_munged(self) -> bool:
         """Check if munge is working correctly."""
-        if not systemd.service_running("munge"):
+        if not systemd.service_running("snap.slurm.munged"):
             return False
 
         # check if munge is working, i.e., can use the credentials correctly
@@ -169,11 +62,14 @@ class SlurmrestdManager:
         try:
             logger.debug("## Testing if munge is working correctly")
             munge = subprocess.Popen(
-                ["munge", "-n"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                ["slurm.munge", "-n"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             if munge is not None:
                 unmunge = subprocess.Popen(
-                    ["unmunge"], stdin=munge.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                    ["slurm.unmunge"],
+                    stdin=munge.stdout,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
                 )
                 output = unmunge.communicate()[0].decode()
             if "Success" in output:
@@ -184,70 +80,3 @@ class SlurmrestdManager:
             logger.error(f"## Error testing munge: {e}")
 
         return False
-
-    def _create_slurmrestd_user_group(self) -> None:
-        """Create the slurmrestd user."""
-        logger.info("#### Creating slurmrestd user and group")
-
-        try:
-            subprocess.check_output(
-                ["groupadd", "--gid", f"{SLURMRESTD_GROUP_GID}", f"{SLURMRESTD_GROUP_NAME}"]
-            )
-        except subprocess.CalledProcessError as e:
-            if e.returncode == 9:
-                logger.warning(f"Group '{SLURMRESTD_GROUP_NAME}' already exists.")
-            else:
-                logger.error(f"Error creating group: '{SLURMRESTD_GROUP_NAME}' - {e}")
-                raise e
-
-        try:
-            subprocess.check_output(
-                [
-                    "adduser",
-                    "--system",
-                    "--gid",
-                    f"{SLURMRESTD_GROUP_GID}",
-                    "--uid",
-                    f"{SLURMRESTD_USER_UID}",
-                    "--no-create-home",
-                    "--home",
-                    "/nonexistent",
-                    f"{SLURMRESTD_USER_NAME}",
-                ]
-            )
-        except subprocess.CalledProcessError as e:
-            if e.returncode == 9:
-                logger.warning(f"User '{SLURMRESTD_USER_NAME}' already exists.")
-            else:
-                logger.error(f"Error creating user: '{SLURMRESTD_USER_NAME} - {e}")
-                raise e
-
-        logger.info("'{SLURMRESTD_USER_NAME}' user and '{SLURMRESTD_GROUP_NAME}' group created.")
-
-    def stop_slurmrestd(self) -> None:
-        """Stop slurmrestd service."""
-        systemd.service_stop("slurmrestd")
-
-    def start_slurmrestd(self) -> None:
-        """Start slurmrestd service."""
-        systemd.service_start("slurmrestd")
-
-    def stop_munge(self) -> None:
-        """Stop munge."""
-        systemd.service_stop("munge")
-
-    def start_munge(self) -> bool:
-        """Start the munge process.
-
-        Return True on success, and False otherwise.
-        """
-        logger.debug("Starting munge.")
-        try:
-            systemd.service_start("munge")
-        # Ignore pyright error for is not a valid exception class, reportGeneralTypeIssues
-        except SlurmrestdManagerError(
-            "Cannot start munge."
-        ) as e:  # pyright: ignore [reportGeneralTypeIssues]
-            logger.error(e)
-            return False
-        return self.check_munged()

--- a/src/slurmrestd_ops.py
+++ b/src/slurmrestd_ops.py
@@ -111,6 +111,7 @@ class SlurmrestdManager:
     def __init__(self):
         self._munge_package = CharmedHPCPackageLifecycleManager("munge")
         self._slurmrestd_package = CharmedHPCPackageLifecycleManager("slurmrestd")
+        self._slurm_plugins_package = CharmedHPCPackageLifecycleManager("slurm-wlm-basic-plugins")
 
     def install(self) -> bool:
         """Install slurmrestd and munge to the system."""
@@ -124,10 +125,13 @@ class SlurmrestdManager:
             return False
         systemd.service_stop("munge")
 
+        if self._slurm_plugins_package.install() is not True:
+            return False
+
         self._create_slurmrestd_user_group()
 
         slurm_conf_dir = Path("/etc/slurm")
-        slurm_conf_dir.mkdir()
+        slurm_conf_dir.mkdir(exist_ok=True)
 
         os.chown(f"{slurm_conf_dir}", SLURMRESTD_USER_UID, SLURMRESTD_GROUP_GID)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,12 +21,10 @@ from pathlib import Path
 from typing import Union
 
 import pytest
-from helpers import NHC
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 SLURMCTLD_DIR = Path(os.getenv("SLURMCTLD_DIR", "../slurmctld-operator"))
-SLURMD_DIR = Path(os.getenv("SLURMD_DIR", "../slurmd-operator"))
 SLURMDBD_DIR = Path(os.getenv("SLURMDBD_DIR", "../slurmdbd-operator"))
 
 
@@ -78,26 +76,6 @@ async def slurmctld_charm(request, ops_test: OpsTest) -> Union[str, Path]:
 
 
 @pytest.fixture(scope="module")
-async def slurmd_charm(request, ops_test: OpsTest) -> Union[str, Path]:
-    """Pack slurmd charm to use for integration tests when --use-local is specified.
-
-    Returns:
-        `str` "slurmd" if --use-local not specified or if SLURMD_DIR does not exist.
-    """
-    if request.config.option.use_local:
-        logger.info("Using local slurmd operator rather than pulling from Charmhub")
-        if SLURMD_DIR.exists():
-            return await ops_test.build_charm(SLURMD_DIR)
-        else:
-            logger.warning(
-                f"{SLURMD_DIR} not found. "
-                f"Defaulting to latest/edge slurmd operator from Charmhub"
-            )
-
-    return "slurmd"
-
-
-@pytest.fixture(scope="module")
 async def slurmdbd_charm(request, ops_test: OpsTest) -> Union[str, Path]:
     """Pack slurmdbd charm to use for integration tests when --use-local is specified.
 
@@ -115,8 +93,3 @@ async def slurmdbd_charm(request, ops_test: OpsTest) -> Union[str, Path]:
             )
 
     return "slurmdbd"
-
-
-def pytest_sessionfinish(session, exitstatus) -> None:
-    """Clean up repository after test session has completed."""
-    Path(NHC).unlink(missing_ok=True)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,12 +24,11 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
+SLURMRESTD = "slurmrestd"
 SLURMCTLD = "slurmctld"
 SLURMDBD = "slurmdbd"
-SLURMRESTD = "slurmrestd"
 DATABASE = "mysql"
 ROUTER = "mysql-router"
-UNIT_NAME = f"{SLURMRESTD}/0"
 
 
 @pytest.mark.abort_on_fail
@@ -93,7 +92,7 @@ async def test_build_and_deploy(
     # Reduce the update status frequency to accelerate the triggering of deferred events.
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[SLURMRESTD], status="active", timeout=1000)
-        assert ops_test.model.units.get(UNIT_NAME).workload_status == "active"
+        assert ops_test.model.applications[SLURMRESTD].units[0].workload_status == "active"
 
 
 @pytest.mark.abort_on_fail
@@ -106,7 +105,7 @@ async def test_build_and_deploy(
 async def test_munge_is_active(ops_test: OpsTest) -> None:
     """Test that munge is active."""
     logger.info("Checking that munge is active inside Juju unit")
-    slurmrestd_unit = ops_test.model.units.get(UNIT_NAME)
+    slurmrestd_unit = ops_test.model.applications[SLURMRESTD].units[0]
     res = (await slurmrestd_unit.ssh("systemctl is-active munge")).strip("\n")
     assert res == "active"
 
@@ -121,6 +120,6 @@ async def test_munge_is_active(ops_test: OpsTest) -> None:
 async def test_slurmrestd_is_active(ops_test: OpsTest) -> None:
     """Test that slurmrestd is active."""
     logger.info("Checking that slurmrestd is active inside Juju unit")
-    slurmrestd_unit = ops_test.model.units.get(UNIT_NAME)
+    slurmrestd_unit = ops_test.model.applications[SLURMRESTD].units[0]
     cmd_res = (await slurmrestd_unit.ssh("systemctl is-active slurmrestd")).strip("\n")
     assert cmd_res == "active"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -91,7 +91,9 @@ async def test_build_and_deploy(
     await ops_test.model.integrate(f"{SLURMRESTD}:{SLURMCTLD}", f"{SLURMCTLD}:{SLURMRESTD}")
     # Reduce the update status frequency to accelerate the triggering of deferred events.
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[SLURMRESTD], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(
+            apps=[SLURMRESTD, SLURMDBD], status="active", timeout=1000
+        )
         assert ops_test.model.applications[SLURMRESTD].units[0].workload_status == "active"
 
 
@@ -106,7 +108,7 @@ async def test_munge_is_active(ops_test: OpsTest) -> None:
     """Test that munge is active."""
     logger.info("Checking that munge is active inside Juju unit")
     slurmrestd_unit = ops_test.model.applications[SLURMRESTD].units[0]
-    res = (await slurmrestd_unit.ssh("systemctl is-active munge")).strip("\n")
+    res = (await slurmrestd_unit.ssh("systemctl is-active snap.slurm.munged")).strip("\n")
     assert res == "active"
 
 
@@ -121,5 +123,5 @@ async def test_slurmrestd_is_active(ops_test: OpsTest) -> None:
     """Test that slurmrestd is active."""
     logger.info("Checking that slurmrestd is active inside Juju unit")
     slurmrestd_unit = ops_test.model.applications[SLURMRESTD].units[0]
-    cmd_res = (await slurmrestd_unit.ssh("systemctl is-active slurmrestd")).strip("\n")
+    cmd_res = (await slurmrestd_unit.ssh("systemctl is-active snap.slurm.slurmrestd")).strip("\n")
     assert cmd_res == "active"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -33,9 +33,10 @@ class TestCharm(unittest.TestCase):
         "interface_slurmctld.Slurmctld.is_joined",
         new_callable=PropertyMock(return_value=True),
     )
-    @patch("slurmrestd_ops.SlurmrestdManager.version", return_value="1.1.1")
-    @patch("slurmrestd_ops.SlurmrestdManager.install")
-    @patch("slurmrestd_ops.CharmedHPCPackageLifecycleManager.install")
+    @patch("os.chown")
+    @patch("charms.hpc_libs.v0.slurm_ops.install")
+    @patch("charms.hpc_libs.v0.slurm_ops.version", return_value="23.11.7")
+    @patch("slurmrestd_ops.LegacySlurmrestdManager.check_munged", return_value=True)
     def test_install_success(self, *_):
         self.harness.charm._stored.slurmctld_available = True
         self.harness.charm.on.install.emit()
@@ -52,7 +53,7 @@ class TestCharm(unittest.TestCase):
         "interface_slurmctld.Slurmctld.is_joined",
         new_callable=PropertyMock(return_value=True),
     )
-    @patch("slurmrestd_ops.SlurmrestdManager.check_munged", return_value=True)
+    @patch("slurmrestd_ops.LegacySlurmrestdManager.check_munged", return_value=True)
     def test_update_status_success(self, *_):
         self.harness.charm._stored.slurm_installed = True
 


### PR DESCRIPTION
## Description

Uses the `slurm_ops` library to manage slurmrestd.
Adds support for running CI 

## How was the code tested?

Locally on an Ubuntu Noble development machine.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
